### PR TITLE
Fix PromptBuilder initialization

### DIFF
--- a/promptBuilder.py
+++ b/promptBuilder.py
@@ -1,21 +1,32 @@
 from langchain_core.prompts import ChatPromptTemplate
 import datetime
 
-class PromptBuilder:
 
-    def __init__(self, systemPrompt: str, input: str, history: list) -> ChatPromptTemplate :
-        
+class PromptBuilder:
+    """Helper class to assemble a chat prompt."""
+
+    def __init__(self, system_prompt: str, user_input: str, history: list) -> None:
+        """Create a prompt template from the given components."""
         today = datetime.datetime.today().strftime("%D")
 
-        if not (systemPrompt := systemPrompt.strip()):
-            systemPrompt = f"You are a helpful assistant. Today the day is {today}. Your goal is to prepare and break down a cohesive plan with ultimate goal to help the user fulfil a request. If you can respond to the user without using a given tool go ahead. Otherwise, invoke the required tool to fulfill your goal. Always reply politely and with humor."
-            
-        prompt = ChatPromptTemplate(
+        if not (system_prompt := (system_prompt or "").strip()):
+            system_prompt = (
+                "You are a helpful assistant. Today the day is "
+                f"{today}. Your goal is to prepare and break down a cohesive plan "
+                "with ultimate goal to help the user fulfil a request. If you can "
+                "respond to the user without using a given tool go ahead. Otherwise, "
+                "invoke the required tool to fulfill your goal. Always reply politely "
+                "and with humor."
+            )
+
+        self.prompt = ChatPromptTemplate(
             [
-                ("system", systemPrompt),
-                ("human", input),
-                ("placeholder", history)
+                ("system", system_prompt),
+                ("human", user_input),
+                ("placeholder", history),
             ]
         )
 
-        return prompt
+    def build(self) -> ChatPromptTemplate:
+        """Return the constructed prompt template."""
+        return self.prompt


### PR DESCRIPTION
## Summary
- fix `PromptBuilder` so `__init__` no longer returns a value
- store the built prompt in `self.prompt`
- add a `build` method for retrieving the prompt template

## Testing
- `python -m py_compile promptBuilder.py agentTools.py anthropicAgent.py`

------
https://chatgpt.com/codex/tasks/task_e_6842164d5f14832c8b82ec7f6842727f